### PR TITLE
docs: set up hub repo for Rayfin open source launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report a bug or issue with Rayfin
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please provide enough detail so we can
+        reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug. What did you expect vs. what actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Run `npm create @microsoft/rayfin@latest`
+        2. Select template ...
+        3. Run `npm install && npm run dev`
+        4. Navigate to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Node version, OS, browser, Rayfin CLI version, etc.
+      placeholder: |
+        - Node: 22.x
+        - OS: macOS 15
+        - Rayfin CLI: 0.5.0
+        - Browser: Chrome 130
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste any relevant error output or attach screenshots.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,38 @@
+name: Feature Request
+description: Suggest a new feature or improvement for Rayfin
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like and why
+        it would be useful.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem does this feature solve? Is it related to a frustration?
+      placeholder: "I'm always frustrated when ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like. How should it work?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you considered any alternative approaches or workarounds?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or references about the feature request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+
+<!-- Brief summary of the change and motivation -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] Other
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] My changes follow the existing code style
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation as needed
+
+## AI disclosure
+
+<!-- If AI tools assisted this contribution, briefly describe how -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Microsoft Open Source Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+Resources:
+
+- [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/)
+- [Microsoft Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+- Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with questions or concerns
+- Employees can reach out at [aka.ms/opensource/moderation-support](https://aka.ms/opensource/moderation-support)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Thank you for your interest in Rayfin.
+We welcome thoughtful contributions from both individual developers and AI-assisted workflows.
+
+## Contributor License Agreement
+
+Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+[Contributor License Agreements portal](https://cla.opensource.microsoft.com).
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
+
+## Code of Conduct
+
+This project follows the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
+or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## How to Contribute
+
+### Reporting Bugs
+
+Use the [Bug Report](https://github.com/microsoft/rayfin/issues/new?template=bug.yml) issue template. Include reproduction steps, environment details, and any relevant logs or screenshots.
+
+### Requesting Features
+
+Use the [Feature Request](https://github.com/microsoft/rayfin/issues/new?template=feature-request.yml) issue template. Describe your use case and the expected behavior.
+
+### Submitting Pull Requests
+
+1. Fork the repository and create a branch for your change.
+2. Keep pull requests scoped to a focused set of changes.
+3. Include a clear description of the change and its rationale.
+4. Run any existing linters, builds, and tests before submitting.
+
+## Commit Messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+**Format:** `<type>(<scope>): <description>`
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation changes |
+| `chore` | CI, scripts, infrastructure |
+| `refactor` | Code restructuring without behavior change |
+
+Examples:
+
+```text
+feat: add support for custom entity validators
+fix: correct auth token refresh on expiry
+docs: update getting started guide
+chore(ci): add Node 22 to test matrix
+```
+
+## AI-Assisted Contributions
+
+We encourage transparent use of AI agents, copilots, and other tools that accelerate high-quality contributions.
+If AI helped you create the contribution, disclose the tools used and how they influenced the work in your pull request or issue summary.
+
+When submitting AI-assisted changes, make sure that you:
+
+- Test the changes yourself and share the results or reproduction steps.
+- Understand the code you are contributing so that you can answer follow-up questions.
+- Explain why the change is needed and how it improves Rayfin.
+- Provide evidence such as screenshots, logs, or test output when fixes or features require verification.
+
+We may close contributions that:
+
+- Appear to be untested or copy-pasted without human review.
+- Offer generic suggestions that do not address specific Rayfin needs.
+- Consist of bulk submissions with no clear analysis or rationale.
+
+Repeated submissions that ignore these guidelines may lead to additional review requirements or contribution limits.
+Respect the maintainers' time and keep communication clear, direct, and professional.
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://docs.github.com/pull-requests)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) Microsoft Corporation.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Rayfin is built on [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/f
 
 This means your Rayfin apps inherit enterprise-grade security and governance out of the box, so you can build fast without compromising on compliance.
 
+👉 [Get started with Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric/getting-started)
+
 ## Local Development (Experimental)
 
 Rayfin supports a pure local development experience — no cloud resources required. This is currently experimental and great for trying out Rayfin or building offline.
@@ -86,6 +88,7 @@ Rayfin supports a pure local development experience — no cloud resources requi
 ## Community
 
 - 📖 [Documentation](https://aka.ms/rayfin/docs)
+- 🏗️ [Get started with Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric/getting-started)
 - 🐛 [Report a Bug](https://github.com/microsoft/rayfin/issues/new?template=bug.yml)
 - 💡 [Request a Feature](https://github.com/microsoft/rayfin/issues/new?template=feature-request.yml)
 - 🐟 [Reddit](https://reddit.com/r/rayfin)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Rayfin supports a pure local development experience — no cloud resources requi
 - 📖 [Documentation](https://aka.ms/rayfin/docs)
 - 🏗️ [Get started with Microsoft Fabric](https://www.microsoft.com/en-us/microsoft-fabric/getting-started)
 - 🐛 [Report a Bug](https://github.com/microsoft/rayfin/issues/new?template=bug.yml)
+- ⚠️ [Known Issues](https://github.com/microsoft/rayfin/issues?q=state%3Aopen%20label%3Aknown-issue)
 - 💡 [Request a Feature](https://github.com/microsoft/rayfin/issues/new?template=feature-request.yml)
 - 🐟 [Reddit](https://reddit.com/r/rayfin)
 - 🤝 [Contributing Guide](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Rayfin supports a pure local development experience — no cloud resources requi
 | [`@microsoft/rayfin-lib`](https://www.npmjs.com/package/@microsoft/rayfin-lib) | Shared library utilities and HTTP client foundation |
 | [`@microsoft/rayfin-tools-common`](https://www.npmjs.com/package/@microsoft/rayfin-tools-common) | Shared utilities for Rayfin tools packages |
 | [`@microsoft/rayfin-docs`](https://www.npmjs.com/package/@microsoft/rayfin-docs) | Rayfin docs indexing and search library |
+| [`@microsoft/rayfin-guide`](https://www.npmjs.com/package/@microsoft/rayfin-guide) | Cross-cutting builder guides for the Rayfin platform |
 | [`@microsoft/rayfin-mcp`](https://www.npmjs.com/package/@microsoft/rayfin-mcp) | Rayfin Model Context Protocol tooling |
 | [`@microsoft/fabric-embedded-host`](https://www.npmjs.com/package/@microsoft/fabric-embedded-host) | PostMessage bridge and embedded mode detection for Fabric iframes |
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ npx rayfin up                          # deploy and run
 - **Typed Data Access** — Schema-driven GraphQL client with compile-time type checking
 - **Static Hosting** — Deploy frontends with `rayfin up staticapp deploy`
 
+## Local Development (Experimental)
+
+Rayfin supports a pure local development experience — no cloud resources required. This is currently experimental and great for trying out Rayfin or building offline.
+
+👉 See the [Todo Local Experimental template](https://github.com/microsoft/awesome-rayfin/tree/main/templates/todo-local-experimental) to get started.
+
 ## Packages
 
 | Package | Description |

--- a/README.md
+++ b/README.md
@@ -49,10 +49,20 @@ Rayfin supports a pure local development experience — no cloud resources requi
 
 | Package | Description |
 |---------|-------------|
+| [`@microsoft/create-rayfin`](https://www.npmjs.com/package/@microsoft/create-rayfin) | Scaffold a Rayfin project with `npm create @microsoft/rayfin@latest` |
 | [`@microsoft/rayfin-cli`](https://www.npmjs.com/package/@microsoft/rayfin-cli) | CLI for scaffolding, deploying, and managing Rayfin apps |
-| [`@microsoft/create-rayfin`](https://www.npmjs.com/package/@microsoft/create-rayfin) | `npm create` initializer for scaffolding new projects |
-| `@microsoft/rayfin-core` | Entity decorators, schema definitions, and core types |
-| `@microsoft/rayfin-client` | Typed data client for querying and mutating entities |
+| [`@microsoft/rayfin-core`](https://www.npmjs.com/package/@microsoft/rayfin-core) | Entity decorators, schema definitions, and core types |
+| [`@microsoft/rayfin-client`](https://www.npmjs.com/package/@microsoft/rayfin-client) | Main client SDK for Rayfin services |
+| [`@microsoft/rayfin-data`](https://www.npmjs.com/package/@microsoft/rayfin-data) | Type-safe client library for Data API Builder endpoints |
+| [`@microsoft/rayfin-auth`](https://www.npmjs.com/package/@microsoft/rayfin-auth) | Authentication utilities for Rayfin SDK |
+| [`@microsoft/rayfin-auth-provider-fabric`](https://www.npmjs.com/package/@microsoft/rayfin-auth-provider-fabric) | Fabric brokered authentication provider for Rayfin SDK |
+| [`@microsoft/rayfin-functions`](https://www.npmjs.com/package/@microsoft/rayfin-functions) | Rayfin functions runtime |
+| [`@microsoft/rayfin-storage`](https://www.npmjs.com/package/@microsoft/rayfin-storage) | Type-safe client library for Rayfin storage operations |
+| [`@microsoft/rayfin-lib`](https://www.npmjs.com/package/@microsoft/rayfin-lib) | Shared library utilities and HTTP client foundation |
+| [`@microsoft/rayfin-tools-common`](https://www.npmjs.com/package/@microsoft/rayfin-tools-common) | Shared utilities for Rayfin tools packages |
+| [`@microsoft/rayfin-docs`](https://www.npmjs.com/package/@microsoft/rayfin-docs) | Rayfin docs indexing and search library |
+| [`@microsoft/rayfin-mcp`](https://www.npmjs.com/package/@microsoft/rayfin-mcp) | Rayfin Model Context Protocol tooling |
+| [`@microsoft/fabric-embedded-host`](https://www.npmjs.com/package/@microsoft/fabric-embedded-host) | PostMessage bridge and embedded mode detection for Fabric iframes |
 
 ## Related Repositories
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <a href="https://aka.ms/rayfin/docs">Docs</a> •
   <a href="https://aka.ms/rayfin">Website</a> •
   <a href="https://github.com/microsoft/awesome-rayfin">Templates</a> •
-  <a href="https://github.com/microsoft/rayfin/issues">Issues</a>
+  <a href="https://github.com/microsoft/rayfin/issues">Issues</a> •
+  <a href="https://reddit.com/r/rayfin">Reddit</a>
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
+<div align="center">
+
+  <h1>🐟 Rayfin</h1>
+  <p>A modern Backend-as-a-Service (BaaS) platform built for the agentic era.<br>
+  Define your data model with TypeScript decorators — Rayfin handles the rest.</p>
+
+  <a href="https://aka.ms/rayfin/docs">Docs</a> •
+  <a href="https://aka.ms/rayfin">Website</a> •
+  <a href="https://github.com/microsoft/awesome-rayfin">Templates</a> •
+  <a href="https://github.com/microsoft/rayfin/issues">Issues</a>
+</div>
+
+---
+
+## Getting Started
+
+```bash
+npm create @microsoft/rayfin@latest
+```
+
+This scaffolds a new Rayfin project with everything you need — data models, auth, and a ready-to-deploy app.
+
+## What is Rayfin?
+
+Rayfin is a **Backend-as-a-Service** platform that lets teams build and ship applications faster. Define your data model with TypeScript decorators and Rayfin handles auth, data APIs, storage, and hosting.
+
+```bash
+npm create @microsoft/rayfin@latest    # scaffold a new project
+npx rayfin up                          # deploy and run
+```
+
+### Key Features
+
+- **Decorator-Based Data Modeling** — Define entities with `@entity()`, `@text()`, `@boolean()`, `@date()`, and other decorators from `@microsoft/rayfin-core`
+- **Authentication** — Fabric Entra SSO in production, mock email/password locally
+- **Typed Data Access** — Schema-driven GraphQL client with compile-time type checking
+- **Static Hosting** — Deploy frontends with `rayfin up staticapp deploy`
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| [`@microsoft/rayfin-cli`](https://www.npmjs.com/package/@microsoft/rayfin-cli) | CLI for scaffolding, deploying, and managing Rayfin apps |
+| [`@microsoft/create-rayfin`](https://www.npmjs.com/package/@microsoft/create-rayfin) | `npm create` initializer for scaffolding new projects |
+| `@microsoft/rayfin-core` | Entity decorators, schema definitions, and core types |
+| `@microsoft/rayfin-client` | Typed data client for querying and mutating entities |
+
+## Related Repositories
+
+| Repository | Description |
+|-----------|-------------|
+| [microsoft/awesome-rayfin](https://github.com/microsoft/awesome-rayfin) | Community templates and resources gallery |
+| [microsoft/fabric-apps-analytic-templates](https://github.com/microsoft/fabric-apps-analytic-templates) | Build data analytics apps based on your data in Fabric |
+
+## Community
+
+- 📖 [Documentation](https://aka.ms/rayfin/docs)
+- 🐛 [Report a Bug](https://github.com/microsoft/rayfin/issues/new?template=bug.yml)
+- 💡 [Request a Feature](https://github.com/microsoft/rayfin/issues/new?template=feature-request.yml)
+- 🤝 [Contributing Guide](CONTRIBUTING.md)
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or services.
+Authorized use of Microsoft trademarks or logos must follow the [Microsoft Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
+Any use of third-party trademarks or logos is subject to those third parties' policies.
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 <div align="center">
 
   <h1>🐟 Rayfin</h1>
-  <p>A modern Backend-as-a-Service (BaaS) platform built for the agentic era.<br>
-  Define your data model with TypeScript decorators — Rayfin handles the rest.</p>
+
+  <p>
+  A modern Backend-as-a-Service (BaaS) platform built for the agentic era.<br>
+  Define your data model with TypeScript decorators — Rayfin provisions and manages the backend for you.
+  </p>
 
   <a href="https://aka.ms/rayfin/docs">Docs</a> •
   <a href="https://aka.ms/rayfin">Website</a> •
@@ -21,23 +24,25 @@
 npm create @microsoft/rayfin@latest
 ```
 
-This scaffolds a new Rayfin project with everything you need — data models, auth, and a ready-to-deploy app.
+This CLI scaffolds a new Rayfin project with everything you need: data models, authentication, APIs, and a ready-to-deploy app.
 
 ## What is Rayfin?
 
-Rayfin is a **Backend-as-a-Service** platform that lets teams build and ship applications faster. Define your data model with TypeScript decorators and Rayfin handles auth, data APIs, storage, and hosting.
+Rayfin is a **fully managed Backend-as-a-Service (BaaS)** platform that helps teams build and ship applications faster without building or operating backend infrastructure.
+
+With Rayfin, you define your data model using TypeScript decorators, and the platform automatically provides and manages:
+- Database
+- Authentication
+- Data APIs
+- Storage
+- Hosting
+
+So you can focus on building your application, not backend services.
 
 ```bash
 npm create @microsoft/rayfin@latest    # scaffold a new project
 npx rayfin up                          # deploy and run
 ```
-
-### Key Features
-
-- **Decorator-Based Data Modeling** — Define entities with `@entity()`, `@text()`, `@boolean()`, `@date()`, and other decorators from `@microsoft/rayfin-core`
-- **Authentication** — Fabric Entra SSO in production, mock email/password locally
-- **Typed Data Access** — Schema-driven GraphQL client with compile-time type checking
-- **Static Hosting** — Deploy frontends with `rayfin up staticapp deploy`
 
 ## Local Development (Experimental)
 

--- a/README.md
+++ b/README.md
@@ -47,23 +47,23 @@ Rayfin supports a pure local development experience — no cloud resources requi
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| [`@microsoft/create-rayfin`](https://www.npmjs.com/package/@microsoft/create-rayfin) | Scaffold a Rayfin project with `npm create @microsoft/rayfin@latest` |
-| [`@microsoft/rayfin-cli`](https://www.npmjs.com/package/@microsoft/rayfin-cli) | CLI for scaffolding, deploying, and managing Rayfin apps |
-| [`@microsoft/rayfin-core`](https://www.npmjs.com/package/@microsoft/rayfin-core) | Entity decorators, schema definitions, and core types |
-| [`@microsoft/rayfin-client`](https://www.npmjs.com/package/@microsoft/rayfin-client) | Main client SDK for Rayfin services |
-| [`@microsoft/rayfin-data`](https://www.npmjs.com/package/@microsoft/rayfin-data) | Type-safe client library for Data API Builder endpoints |
-| [`@microsoft/rayfin-auth`](https://www.npmjs.com/package/@microsoft/rayfin-auth) | Authentication utilities for Rayfin SDK |
-| [`@microsoft/rayfin-auth-provider-fabric`](https://www.npmjs.com/package/@microsoft/rayfin-auth-provider-fabric) | Fabric brokered authentication provider for Rayfin SDK |
-| [`@microsoft/rayfin-functions`](https://www.npmjs.com/package/@microsoft/rayfin-functions) | Rayfin functions runtime |
-| [`@microsoft/rayfin-storage`](https://www.npmjs.com/package/@microsoft/rayfin-storage) | Type-safe client library for Rayfin storage operations |
-| [`@microsoft/rayfin-lib`](https://www.npmjs.com/package/@microsoft/rayfin-lib) | Shared library utilities and HTTP client foundation |
-| [`@microsoft/rayfin-tools-common`](https://www.npmjs.com/package/@microsoft/rayfin-tools-common) | Shared utilities for Rayfin tools packages |
-| [`@microsoft/rayfin-docs`](https://www.npmjs.com/package/@microsoft/rayfin-docs) | Rayfin docs indexing and search library |
-| [`@microsoft/rayfin-guide`](https://www.npmjs.com/package/@microsoft/rayfin-guide) | Cross-cutting builder guides for the Rayfin platform |
-| [`@microsoft/rayfin-mcp`](https://www.npmjs.com/package/@microsoft/rayfin-mcp) | Rayfin Model Context Protocol tooling |
-| [`@microsoft/fabric-embedded-host`](https://www.npmjs.com/package/@microsoft/fabric-embedded-host) | PostMessage bridge and embedded mode detection for Fabric iframes |
+| Package | Version | Description |
+|---------|---------|-------------|
+| [`@microsoft/create-rayfin`](https://www.npmjs.com/package/@microsoft/create-rayfin) | [![npm](https://img.shields.io/npm/v/@microsoft/create-rayfin)](https://www.npmjs.com/package/@microsoft/create-rayfin) | Scaffold a Rayfin project with `npm create @microsoft/rayfin@latest` |
+| [`@microsoft/rayfin-cli`](https://www.npmjs.com/package/@microsoft/rayfin-cli) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-cli)](https://www.npmjs.com/package/@microsoft/rayfin-cli) | CLI for scaffolding, deploying, and managing Rayfin apps |
+| [`@microsoft/rayfin-core`](https://www.npmjs.com/package/@microsoft/rayfin-core) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-core)](https://www.npmjs.com/package/@microsoft/rayfin-core) | Entity decorators, schema definitions, and core types |
+| [`@microsoft/rayfin-client`](https://www.npmjs.com/package/@microsoft/rayfin-client) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-client)](https://www.npmjs.com/package/@microsoft/rayfin-client) | Main client SDK for Rayfin services |
+| [`@microsoft/rayfin-data`](https://www.npmjs.com/package/@microsoft/rayfin-data) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-data)](https://www.npmjs.com/package/@microsoft/rayfin-data) | Type-safe client library for Data API Builder endpoints |
+| [`@microsoft/rayfin-auth`](https://www.npmjs.com/package/@microsoft/rayfin-auth) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-auth)](https://www.npmjs.com/package/@microsoft/rayfin-auth) | Authentication utilities for Rayfin SDK |
+| [`@microsoft/rayfin-auth-provider-fabric`](https://www.npmjs.com/package/@microsoft/rayfin-auth-provider-fabric) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-auth-provider-fabric)](https://www.npmjs.com/package/@microsoft/rayfin-auth-provider-fabric) | Fabric brokered authentication provider for Rayfin SDK |
+| [`@microsoft/rayfin-functions`](https://www.npmjs.com/package/@microsoft/rayfin-functions) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-functions)](https://www.npmjs.com/package/@microsoft/rayfin-functions) | Rayfin functions runtime |
+| [`@microsoft/rayfin-storage`](https://www.npmjs.com/package/@microsoft/rayfin-storage) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-storage)](https://www.npmjs.com/package/@microsoft/rayfin-storage) | Type-safe client library for Rayfin storage operations |
+| [`@microsoft/rayfin-lib`](https://www.npmjs.com/package/@microsoft/rayfin-lib) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-lib)](https://www.npmjs.com/package/@microsoft/rayfin-lib) | Shared library utilities and HTTP client foundation |
+| [`@microsoft/rayfin-tools-common`](https://www.npmjs.com/package/@microsoft/rayfin-tools-common) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-tools-common)](https://www.npmjs.com/package/@microsoft/rayfin-tools-common) | Shared utilities for Rayfin tools packages |
+| [`@microsoft/rayfin-docs`](https://www.npmjs.com/package/@microsoft/rayfin-docs) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-docs)](https://www.npmjs.com/package/@microsoft/rayfin-docs) | Rayfin docs indexing and search library |
+| [`@microsoft/rayfin-guide`](https://www.npmjs.com/package/@microsoft/rayfin-guide) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-guide)](https://www.npmjs.com/package/@microsoft/rayfin-guide) | Cross-cutting builder guides for the Rayfin platform |
+| [`@microsoft/rayfin-mcp`](https://www.npmjs.com/package/@microsoft/rayfin-mcp) | [![npm](https://img.shields.io/npm/v/@microsoft/rayfin-mcp)](https://www.npmjs.com/package/@microsoft/rayfin-mcp) | Rayfin Model Context Protocol tooling |
+| [`@microsoft/fabric-embedded-host`](https://www.npmjs.com/package/@microsoft/fabric-embedded-host) | [![npm](https://img.shields.io/npm/v/@microsoft/fabric-embedded-host)](https://www.npmjs.com/package/@microsoft/fabric-embedded-host) | PostMessage bridge and embedded mode detection for Fabric iframes |
 
 ## Related Repositories
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ npm create @microsoft/rayfin@latest    # scaffold a new project
 npx rayfin up                          # deploy and run
 ```
 
+## Why Fabric?
+
+Rayfin is built on [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/fundamentals/microsoft-fabric-overview), which provides centralized data discovery, access control, and governance capabilities -- helping organizations manage data access, sharing, and compliance consistently across workloads.
+
+This means your Rayfin apps inherit enterprise-grade security and governance out of the box, so you can build fast without compromising on compliance.
+
 ## Local Development (Experimental)
 
 Rayfin supports a pure local development experience — no cloud resources required. This is currently experimental and great for trying out Rayfin or building offline.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Rayfin supports a pure local development experience — no cloud resources requi
 - 📖 [Documentation](https://aka.ms/rayfin/docs)
 - 🐛 [Report a Bug](https://github.com/microsoft/rayfin/issues/new?template=bug.yml)
 - 💡 [Request a Feature](https://github.com/microsoft/rayfin/issues/new?template=feature-request.yml)
+- 🐟 [Reddit](https://reddit.com/r/rayfin)
 - 🤝 [Contributing Guide](CONTRIBUTING.md)
 
 ## Trademarks

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+<!-- BEGIN MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
+
+<!-- markdownlint-disable-next-line first-line-h1 -->
+## Security
+
+Microsoft takes the security of our software products and services seriously, which
+includes all source code repositories in our GitHub organizations.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+For security reporting information, locations, contact information, and policies,
+please review the latest guidance for Microsoft repositories at
+[https://aka.ms/SECURITY.md](https://aka.ms/SECURITY.md).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,34 @@
+# Support
+
+Rayfin is an open-source Backend-as-a-Service platform built for the agentic era.
+
+## How to File Issues and Get Help
+
+### GitHub Issues
+
+Engineers who contribute to and work on Rayfin periodically monitor and review issues added to [the repository's issues list](https://github.com/microsoft/rayfin/issues). The period of review is not set by a service level agreement (SLA), and resolution is not guaranteed. When an issue is raised, a member of the team will respond as soon as possible; please be patient.
+
+Repository issues track bugs, questions, and feature requests. Creating issues requires a GitHub account; issue templates prompt for details that will help engineers reproduce your issue and more effectively complete an investigation. Repository issues may be added to the backlog by engineers and become triaged in our future roadmap.
+
+We recommend searching for existing issues similar to yours before creating a new one. Commenting on existing issues helps coalesce recurring issues and helps engineers evaluate severity and find better resolutions.
+
+### Before Submitting an Issue
+
+First, please do a search in [open issues](https://github.com/microsoft/rayfin/issues) to see if the issue or feature request has already been filed.
+
+If you find your issue already exists, make relevant comments and add your [reaction](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments). Use a reaction in place of a "+1" comment.
+
+:+1: - upvote
+
+:-1: - downvote
+
+## Resources
+
+- [Documentation](https://aka.ms/rayfin/docs)
+- [GitHub Repository](https://github.com/microsoft/rayfin)
+- [Community Templates](https://github.com/microsoft/awesome-rayfin)
+
+## Security Issues
+
+Security issues and bugs should be reported privately, via email, to the Microsoft Security Response Center (<secure@microsoft.com>). You should receive a response within 24 hours.
+For more information, review [SECURITY.md](SECURITY.md).

--- a/packages/guide/README.md
+++ b/packages/guide/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-guide
+
+Cross-cutting builder guides for the Rayfin platform — discovered by `@microsoft/rayfin-docs` via the `rayfinDocs` package.json field convention.
+
+📦 **npm**: [@microsoft/rayfin-guide](https://www.npmjs.com/package/@microsoft/rayfin-guide)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-guide
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/tools/cli/README.md
+++ b/packages/tools/cli/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-cli
+
+Command-line interface for Rayfin platform
+
+📦 **npm**: [@microsoft/rayfin-cli](https://www.npmjs.com/package/@microsoft/rayfin-cli)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-cli
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/tools/common/README.md
+++ b/packages/tools/common/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-tools-common
+
+Shared utilities for Rayfin tools packages
+
+📦 **npm**: [@microsoft/rayfin-tools-common](https://www.npmjs.com/package/@microsoft/rayfin-tools-common)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-tools-common
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/tools/create-rayfin/README.md
+++ b/packages/tools/create-rayfin/README.md
@@ -1,0 +1,17 @@
+# @microsoft/create-rayfin
+
+Scaffold a Rayfin project with npm create @microsoft/rayfin@latest
+
+📦 **npm**: [@microsoft/create-rayfin](https://www.npmjs.com/package/@microsoft/create-rayfin)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/create-rayfin
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/tools/docs-lib/README.md
+++ b/packages/tools/docs-lib/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-docs
+
+Rayfin docs indexing and search library
+
+📦 **npm**: [@microsoft/rayfin-docs](https://www.npmjs.com/package/@microsoft/rayfin-docs)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-docs
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/tools/mcp/README.md
+++ b/packages/tools/mcp/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-mcp
+
+Rayfin Model Context Protocol tooling
+
+📦 **npm**: [@microsoft/rayfin-mcp](https://www.npmjs.com/package/@microsoft/rayfin-mcp)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-mcp
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/auth-provider-fabric/README.md
+++ b/packages/typescript-sdk/auth-provider-fabric/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-auth-provider-fabric
+
+Fabric brokered authentication provider for Rayfin SDK
+
+📦 **npm**: [@microsoft/rayfin-auth-provider-fabric](https://www.npmjs.com/package/@microsoft/rayfin-auth-provider-fabric)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-auth-provider-fabric
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/auth/README.md
+++ b/packages/typescript-sdk/auth/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-auth
+
+Authentication utilities for Rayfin SDK
+
+📦 **npm**: [@microsoft/rayfin-auth](https://www.npmjs.com/package/@microsoft/rayfin-auth)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-auth
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/client/README.md
+++ b/packages/typescript-sdk/client/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-client
+
+Main client SDK for Rayfin services
+
+📦 **npm**: [@microsoft/rayfin-client](https://www.npmjs.com/package/@microsoft/rayfin-client)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-client
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/core/README.md
+++ b/packages/typescript-sdk/core/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-core
+
+TypeScript library for code-first Data API Builder configuration generation
+
+📦 **npm**: [@microsoft/rayfin-core](https://www.npmjs.com/package/@microsoft/rayfin-core)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-core
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/data/README.md
+++ b/packages/typescript-sdk/data/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-data
+
+Type-safe client library for Data API Builder endpoints
+
+📦 **npm**: [@microsoft/rayfin-data](https://www.npmjs.com/package/@microsoft/rayfin-data)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-data
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/fabric-embedded-host/README.md
+++ b/packages/typescript-sdk/fabric-embedded-host/README.md
@@ -1,0 +1,17 @@
+# @microsoft/fabric-embedded-host
+
+Shared postMessage bridge protocol and embedded mode detection for Rayfin SDKs hosted inside Fabric iframes
+
+📦 **npm**: [@microsoft/fabric-embedded-host](https://www.npmjs.com/package/@microsoft/fabric-embedded-host)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/fabric-embedded-host
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/functions/README.md
+++ b/packages/typescript-sdk/functions/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-functions
+
+Rayfin functions runtime
+
+📦 **npm**: [@microsoft/rayfin-functions](https://www.npmjs.com/package/@microsoft/rayfin-functions)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-functions
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/lib/README.md
+++ b/packages/typescript-sdk/lib/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-lib
+
+Shared library utilities and HTTP client foundation for the Rayfin platform
+
+📦 **npm**: [@microsoft/rayfin-lib](https://www.npmjs.com/package/@microsoft/rayfin-lib)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-lib
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.

--- a/packages/typescript-sdk/storage/README.md
+++ b/packages/typescript-sdk/storage/README.md
@@ -1,0 +1,17 @@
+# @microsoft/rayfin-storage
+
+Type-safe client library for Rayfin storage operations
+
+📦 **npm**: [@microsoft/rayfin-storage](https://www.npmjs.com/package/@microsoft/rayfin-storage)
+
+> **Source code coming soon.** This package is published on npm and the full source will be available in this repository shortly.
+>
+> In the meantime, you can install and use it today:
+>
+> ```bash
+> npm install @microsoft/rayfin-storage
+> ```
+
+## Documentation
+
+See the [Rayfin docs](https://aka.ms/rayfin/docs) for usage guides and API reference.


### PR DESCRIPTION
## Description

Prepares the microsoft/rayfin hub repo for the open source launch. This repo serves as the central landing point for the Rayfin project, linking to all public packages, related repositories, and community resources.

**What's included:**
- README with getting started (`npm create @microsoft/rayfin@latest`), feature overview, full package table with npm version badges, related repos, and community links (docs, Reddit, issues)
- Standard Microsoft OSS files: LICENSE (MIT), SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, SUPPORT.md
- GitHub issue templates for bug reports and feature requests
- PR template with checklist and AI disclosure
- Stub folders under `packages/` mirroring the project-rayfin monorepo structure (15 published `@microsoft/` packages), each with a README linking to npm and noting source code is coming soon
- Experimental local development section pointing to the todo-local-experimental template

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Other

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] I have updated documentation as needed

## AI disclosure

This PR was authored with GitHub Copilot CLI assistance for file generation, package registry verification, and cross-referencing the rush.json package list.