### PR TITLE
feat: add guided setup prompt for coding agents (start.md)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Rayfin agent skills for AI coding assistants",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {
       "name": "rayfin",
       "description": "Getting-started router for Rayfin - gets an agent from zero into a working Rayfin project via the Rayfin CLI (scaffold/init), then hands off to the version-locked in-project skill the scaffold installs.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Rayfin agent skills for AI coding assistants",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {
       "name": "rayfin",
       "description": "Getting-started router for Rayfin — gets an agent from zero into a working Rayfin project via the Rayfin CLI (scaffold/init), then hands off to the version-locked in-project skill the scaffold installs.",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "source": "./"
     }
   ]

--- a/.github/workflows/validate-start-prompt.yml
+++ b/.github/workflows/validate-start-prompt.yml
@@ -1,0 +1,55 @@
+name: Validate start.md prompt
+
+on:
+  pull_request:
+    paths:
+      - content/start.md
+      - .github/workflows/validate-start-prompt.yml
+  push:
+    branches: [main]
+    paths:
+      - content/start.md
+      - .github/workflows/validate-start-prompt.yml
+
+permissions:
+  contents: read
+
+jobs:
+  no-straight-quotes:
+    name: No straight double quotes in start.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Reject straight double quotes
+        run: |
+          if grep -n '"' content/start.md; then
+            echo
+            echo "::error file=content/start.md::start.md must not contain straight double quotes"
+            cat <<'EOF'
+          content/start.md contains straight double quotes (") on the lines above.
+
+          Why this breaks:
+            The README documents launching the prompt as a single command, which
+            fetches this file and passes it to copilot as a native-process argument:
+
+              copilot -i "$(curl -sSfL https://aka.ms/rayfin/start.md)"
+              copilot -i (irm https://aka.ms/rayfin/start.md)
+
+            Windows PowerShell 5.1 is still the default shell on Windows, and its
+            legacy argument parser splits native-command arguments on embedded
+            straight double quotes. The prompt arrives truncated, with the remainder
+            passed as stray operands, so the user lands in a broken session.
+            pwsh 7 handles it correctly, but 5.1 is the default path we document.
+
+          How to fix:
+            Reword to avoid the quotes (preferred), for example
+              "20 or later"  ->  20-or-later
+            or use single quotes, or backticks for inline code.
+
+          Apostrophes and backticks are fine: only straight double quotes break the
+          PowerShell 5.1 argument parser.
+          EOF
+            exit 1
+          fi
+          echo "OK: no straight double quotes in content/start.md"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ This CLI scaffolds a new Rayfin project with everything you need: data models, a
 > On Windows (PowerShell):
 >
 > ```powershell
-> $prompt = Invoke-RestMethod 'https://aka.ms/rayfin/start.md'
-> copilot -i $prompt
+> copilot -i (irm https://aka.ms/rayfin/start.md)
 > ```
 >
 > This loads the [Rayfin starter prompt](content/start.md): it checks your environment, picks a template, scaffolds the project, and helps you customize.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ This CLI scaffolds a new Rayfin project with everything you need: data models, a
 > copilot -i "$(curl -sSfL https://aka.ms/rayfin/start.md)"
 > ```
 >
+> On Windows (PowerShell):
+>
+> ```powershell
+> $prompt = Invoke-RestMethod 'https://aka.ms/rayfin/start.md'
+> copilot -i $prompt
+> ```
+>
 > This loads the [Rayfin starter prompt](content/start.md): it checks your environment, picks a template, scaffolds the project, and helps you customize.
 
 ### Agent plugin

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This CLI scaffolds a new Rayfin project with everything you need: data models, a
 > copilot -i "$(curl -sSfL https://aka.ms/rayfin/start.md)"
 > ```
 >
-> This loads the [Rayfin starter prompt](docs/START.md): it checks your environment, picks a template, scaffolds the project, and helps you customize.
+> This loads the [Rayfin starter prompt](content/start.md): it checks your environment, picks a template, scaffolds the project, and helps you customize.
 
 ### Agent plugin
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ npm create @microsoft/rayfin@latest
 
 This CLI scaffolds a new Rayfin project with everything you need: data models, authentication, APIs, and a ready-to-deploy app.
 
+> [!TIP]
+> **Prefer to build with a coding agent?** Hand it the guided setup prompt and
+> describe what you want to build:
+>
+> ```bash
+> copilot -i "$(curl -sSfL https://aka.ms/rayfin/start.md)"
+> ```
+>
+> This loads the [Rayfin starter prompt](docs/START.md): it checks your environment, picks a template, scaffolds the project, and helps you customize.
+
 ### Agent plugin
 
 Install the Rayfin getting-started skill through your agent's native marketplace or extension manager:

--- a/content/start.md
+++ b/content/start.md
@@ -2,7 +2,7 @@
 
 You're helping a developer create a new Rayfin project. Rayfin is a TypeScript Backend-as-a-Service: decorate data models to get auto-generated APIs (REST + GraphQL), typed clients, auth, storage, and a local dev stack.
 
-**Core rule:** Rayfin's specifics are version-locked per project, so once a project exists, never answer schema/API/auth/storage/deployment questions from memory: remembered Rayfin APIs are routinely wrong. Defer to the project's installed skill, `rayfin docs`, and `rayfin` MCP (Step 4). Keep this bootstrap light on Rayfin internals.
+**Core rule:** Rayfin's specifics are version-locked per project, so once a project exists, never answer schema/API/auth/storage/deployment questions from memory: remembered Rayfin APIs are routinely wrong. Defer to the project's installed skill, `rayfin docs`, and `rayfin` MCP (Step 4).
 
 **One question at a time:** whenever you need input from the user, ask a single question and wait for the answer before asking the next.
 
@@ -32,8 +32,6 @@ Fetch and read this URL:
 
 Then follow it to detect whether you're already in a Rayfin project, in an existing non-Rayfin app, or in an empty directory, and to run the right command for that case. Feed it what you learned in Step 1: what the user wants to build, and a kebab-case project name you've confirmed with them.
 
-Two things that skill assumes and this prompt has already covered: Node is installed (Step 2), and you're not a TTY, so keep passing `-y` to `npx`. If `npx` errors, Node may be missing; see Step 2.
-
 Once it has scaffolded, make sure you're at the project root before continuing: `create-rayfin` creates a child directory, while an in-place init leaves you where you are. Then continue to Step 4.
 
 ## Step 4: Load the in-project skill, then plan & customize
@@ -46,9 +44,3 @@ Before writing any Rayfin-specific code, hand off to the project's authoritative
 Then plan before you build: outline the first changes for what they described in Step 1 (entities under `rayfin/data/`, views under `src/`, packages to install) and confirm that plan with the user before writing code. If your tooling has a planning mode, use it.
 
 Don't start the backend or frontend; the user runs the app themselves when ready (see the project's `README.md`).
-
-## Useful links
-
-- Docs: <http://aka.ms/rayfin/docs>
-- Scaffolder: <https://www.npmjs.com/package/@microsoft/create-rayfin>
-- Community template gallery: <https://github.com/microsoft/awesome-rayfin>

--- a/content/start.md
+++ b/content/start.md
@@ -13,16 +13,15 @@ internals.
 **One question at a time:** whenever you need input from the user, ask a single
 question and wait for the answer before asking the next.
 
-## Step 1: Detect context and ask what they want to build
+## Step 1: Ask what they want to build
 
-First, check the current directory: context signals are enough, even if you can't
-open the files. It's already a Rayfin project if it has `rayfin/rayfin.yml` or a
-`package.json` with `@microsoft/rayfin-*` deps. Never create a project nested inside
-or beside an existing app.
+Ask what they want to build, and confirm a kebab-case project name. Infer whether it
+targets Microsoft Fabric or should be self-contained, only clarifying if it's unclear.
+This guides the template choice in Step 3 and the customization in Step 4.
 
-Then ask what they want to build. Infer whether it targets Microsoft Fabric or should
-be self-contained, only clarifying if it's unclear. This guides the template and
-later customization.
+Keep it short if the working directory already looks like an existing app: Step 3
+determines the exact situation and never creates a project nested inside or beside
+another one.
 
 ## Step 2: Check prerequisites
 
@@ -37,43 +36,26 @@ Don't proceed until `node --version` reports v20+.
 
 ## Step 3: Get into a project
 
-Act on the context from Step 1. You're not a TTY, so always pass `-y` to `npx` (bare
-`npm create` can mishandle piped stdin and strip flags).
+Don't scaffold from memory: fetch the getting-started skill and follow it. It is the
+canonical source for project detection, the default template, and the exact CLI
+commands, and it is kept up to date as those change.
 
-- **Already in a Rayfin project:** don't scaffold; they may have run this by mistake.
-  Confirm they mean to work here (else ask for an empty target dir for a new project),
-  then go to Step 4.
-- **Existing non-Rayfin app here:** confirm, then add Rayfin in place with
-  `npx -y rayfin init` (no template). Then Step 4.
-- **Empty directory:** scaffold a new child project. Map the Step 1 answer to a
-  template, then list the live set and pick the closest fit:
+```bash
+curl -sSfL https://raw.githubusercontent.com/microsoft/rayfin/main/skills/rayfin-getting-started/SKILL.md
+```
 
-  ```bash
-  npx -y @microsoft/create-rayfin@latest --list-templates   # JSON of gallery templates
-  ```
+Read it, then follow it to detect whether you're already in a Rayfin project, in an
+existing non-Rayfin app, or in an empty directory, and to run the right command for
+that case. Feed it what you learned in Step 1: what the user wants to build, and a
+kebab-case project name you've confirmed with them.
 
-  If unavailable, fall back to these built-in slugs (default `dataapp` for Fabric, or
-  `todoapp` if self-contained / no Fabric workspace):
+Two things that skill assumes and this prompt has already covered: Node is installed
+(Step 2), and you're not a TTY, so keep passing `-y` to `npx`. If `npx` errors, Node
+may be missing; see Step 2.
 
-  - **`dataapp`** _(default)_: Microsoft Fabric data analytics app.
-  - **`todoapp`**: full app (auth, entities, frontend); best to learn Rayfin end-to-end.
-  - **`gettingstartedauth`**: minimal app with auth wired up; add your own data model.
-  - **`blankapp`**: bare scaffolding (auth + data services, no entities/UI).
-
-  For more options, including user-contributed ones, see the community gallery linked
-  at the end.
-
-  Prefer a template matching their domain over a blank one. Propose a kebab-case
-  project name, confirm it, then:
-
-  ```bash
-  npx -y @microsoft/create-rayfin@latest --project-name <name> --template <slug>
-  ```
-
-The scaffolder (or `init`) creates the project, installs dependencies, and writes
-agent rules + an MCP config, so don't redo that work. `cd` into the new `<name>/`
-child dir (`rayfin init` works in place, so you're already there). If `npx` errors,
-Node may be missing; see Step 2.
+Once it has scaffolded, make sure you're at the project root before continuing:
+`create-rayfin` creates a child directory, while an in-place init leaves you where you
+are. Then continue to Step 4.
 
 ## Step 4: Load the in-project skill, then plan & customize
 
@@ -86,9 +68,10 @@ version-locked sources:
    guessing. The skill file and `rayfin docs` work as soon as the project exists, so
    don't block waiting on the MCP reload.
 
-Then enter plan mode and outline the first changes for what they described in Step 1:
-entities under `rayfin/data/`, views under `src/`, and packages to install. Confirm
-with the user before writing code.
+Then plan before you build: outline the first changes for what they described in
+Step 1 (entities under `rayfin/data/`, views under `src/`, packages to install) and
+confirm that plan with the user before writing code. If your tooling has a planning
+mode, use it.
 
 Don't start the backend or frontend; the user runs the app themselves when ready (see
 the project's `README.md`).

--- a/content/start.md
+++ b/content/start.md
@@ -26,7 +26,7 @@ Don't proceed until `node --version` reports v20+.
 
 Don't scaffold from memory: fetch the getting-started skill and follow it. It is the canonical source for project detection, the default template, and the exact CLI commands, and it is kept up to date as those change.
 
-Fetch and read this URL with your web fetch capability, rather than a shell command, so this works the same on any platform:
+Fetch and read this URL:
 
 <https://raw.githubusercontent.com/microsoft/rayfin/main/skills/rayfin-getting-started/SKILL.md>
 

--- a/content/start.md
+++ b/content/start.md
@@ -1,32 +1,20 @@
 # Rayfin: New Project Setup
 
-You're helping a developer create a new Rayfin project. Rayfin is a TypeScript
-Backend-as-a-Service: decorate data models to get auto-generated APIs (REST +
-GraphQL), typed clients, auth, storage, and a local dev stack.
+You're helping a developer create a new Rayfin project. Rayfin is a TypeScript Backend-as-a-Service: decorate data models to get auto-generated APIs (REST + GraphQL), typed clients, auth, storage, and a local dev stack.
 
-**Core rule:** Rayfin's specifics are version-locked per project, so once a project
-exists, never answer schema/API/auth/storage/deployment questions from memory:
-remembered Rayfin APIs are routinely wrong. Defer to the project's installed skill,
-`rayfin docs`, and `rayfin` MCP (Step 4). Keep this bootstrap light on Rayfin
-internals.
+**Core rule:** Rayfin's specifics are version-locked per project, so once a project exists, never answer schema/API/auth/storage/deployment questions from memory: remembered Rayfin APIs are routinely wrong. Defer to the project's installed skill, `rayfin docs`, and `rayfin` MCP (Step 4). Keep this bootstrap light on Rayfin internals.
 
-**One question at a time:** whenever you need input from the user, ask a single
-question and wait for the answer before asking the next.
+**One question at a time:** whenever you need input from the user, ask a single question and wait for the answer before asking the next.
 
 ## Step 1: Ask what they want to build
 
-Ask what they want to build, and confirm a kebab-case project name. Infer whether it
-targets Microsoft Fabric or should be self-contained, only clarifying if it's unclear.
-This guides the template choice in Step 3 and the customization in Step 4.
+Ask what they want to build, and confirm a kebab-case project name. Infer whether it targets Microsoft Fabric or should be self-contained, only clarifying if it's unclear. This guides the template choice in Step 3 and the customization in Step 4.
 
-Keep it short if the working directory already looks like an existing app: Step 3
-determines the exact situation and never creates a project nested inside or beside
-another one.
+Keep it short if the working directory already looks like an existing app: Step 3 determines the exact situation and never creates a project nested inside or beside another one.
 
 ## Step 2: Check prerequisites
 
-Before running any `npx` command: `node --version` (need 20+) and `git --version`.
-Install anything missing first:
+Before running any `npx` command: `node --version` (need 20+) and `git --version`. Install anything missing first:
 
 - macOS: `brew install node git`
 - Windows: `winget install -e --id OpenJS.NodeJS.LTS Git.Git`
@@ -36,45 +24,28 @@ Don't proceed until `node --version` reports v20+.
 
 ## Step 3: Get into a project
 
-Don't scaffold from memory: fetch the getting-started skill and follow it. It is the
-canonical source for project detection, the default template, and the exact CLI
-commands, and it is kept up to date as those change.
+Don't scaffold from memory: fetch the getting-started skill and follow it. It is the canonical source for project detection, the default template, and the exact CLI commands, and it is kept up to date as those change.
 
 ```bash
 curl -sSfL https://raw.githubusercontent.com/microsoft/rayfin/main/skills/rayfin-getting-started/SKILL.md
 ```
 
-Read it, then follow it to detect whether you're already in a Rayfin project, in an
-existing non-Rayfin app, or in an empty directory, and to run the right command for
-that case. Feed it what you learned in Step 1: what the user wants to build, and a
-kebab-case project name you've confirmed with them.
+Read it, then follow it to detect whether you're already in a Rayfin project, in an existing non-Rayfin app, or in an empty directory, and to run the right command for that case. Feed it what you learned in Step 1: what the user wants to build, and a kebab-case project name you've confirmed with them.
 
-Two things that skill assumes and this prompt has already covered: Node is installed
-(Step 2), and you're not a TTY, so keep passing `-y` to `npx`. If `npx` errors, Node
-may be missing; see Step 2.
+Two things that skill assumes and this prompt has already covered: Node is installed (Step 2), and you're not a TTY, so keep passing `-y` to `npx`. If `npx` errors, Node may be missing; see Step 2.
 
-Once it has scaffolded, make sure you're at the project root before continuing:
-`create-rayfin` creates a child directory, while an in-place init leaves you where you
-are. Then continue to Step 4.
+Once it has scaffolded, make sure you're at the project root before continuing: `create-rayfin` creates a child directory, while an in-place init leaves you where you are. Then continue to Step 4.
 
 ## Step 4: Load the in-project skill, then plan & customize
 
-Before writing any Rayfin-specific code, hand off to the project's authoritative,
-version-locked sources:
+Before writing any Rayfin-specific code, hand off to the project's authoritative, version-locked sources:
 
-1. Load `.agents/skills/rayfin/SKILL.md` and follow it; if your tooling supports it,
-   reload tools to bring the `rayfin` MCP online.
-2. Look up version-matched APIs via `rayfin docs` and the `rayfin` MCP instead of
-   guessing. The skill file and `rayfin docs` work as soon as the project exists, so
-   don't block waiting on the MCP reload.
+1. Load `.agents/skills/rayfin/SKILL.md` and follow it; if your tooling supports it, reload tools to bring the `rayfin` MCP online.
+2. Look up version-matched APIs via `rayfin docs` and the `rayfin` MCP instead of guessing. The skill file and `rayfin docs` work as soon as the project exists, so don't block waiting on the MCP reload.
 
-Then plan before you build: outline the first changes for what they described in
-Step 1 (entities under `rayfin/data/`, views under `src/`, packages to install) and
-confirm that plan with the user before writing code. If your tooling has a planning
-mode, use it.
+Then plan before you build: outline the first changes for what they described in Step 1 (entities under `rayfin/data/`, views under `src/`, packages to install) and confirm that plan with the user before writing code. If your tooling has a planning mode, use it.
 
-Don't start the backend or frontend; the user runs the app themselves when ready (see
-the project's `README.md`).
+Don't start the backend or frontend; the user runs the app themselves when ready (see the project's `README.md`).
 
 ## Useful links
 

--- a/content/start.md
+++ b/content/start.md
@@ -1,0 +1,100 @@
+# Rayfin — New Project Setup
+
+You're helping a developer create a new Rayfin project. Rayfin is a TypeScript
+Backend-as-a-Service: decorate data models to get auto-generated APIs (REST +
+GraphQL), typed clients, auth, storage, and a local dev stack.
+
+**Core rule:** Rayfin's specifics are version-locked per project, so once a project
+exists, never answer schema/API/auth/storage/deployment questions from memory:
+remembered Rayfin APIs are routinely wrong. Defer to the project's installed skill,
+`rayfin docs`, and `rayfin` MCP (Step 4). Keep this bootstrap light on Rayfin
+internals.
+
+**One question at a time:** whenever you need input from the user, ask a single
+question and wait for the answer before asking the next.
+
+## Step 1 — Detect context and ask what they want to build
+
+First, check the current directory: context signals are enough, even if you can't
+open the files. It's already a Rayfin project if it has `rayfin/rayfin.yml` or a
+`package.json` with `@microsoft/rayfin-*` deps. Never create a project nested inside
+or beside an existing app.
+
+Then ask what they want to build. Infer whether it targets Microsoft Fabric or should
+be self-contained, only clarifying if it's unclear. This guides the template and
+later customization.
+
+## Step 2 — Check prerequisites
+
+Before running any `npx` command: `node --version` (need 20+) and `git --version`.
+Install anything missing first:
+
+- macOS: `brew install node git`
+- Windows: `winget install -e --id OpenJS.NodeJS.LTS Git.Git`
+- Linux (Debian/Ubuntu): Node from [nodejs.org/en/download](https://nodejs.org/en/download), then `sudo apt install -y git`
+
+Don't proceed until `node --version` reports v20+.
+
+## Step 3 — Get into a project
+
+Act on the context from Step 1. You're not a TTY, so always pass `-y` to `npx` (bare
+`npm create` can mishandle piped stdin and strip flags).
+
+- **Already in a Rayfin project:** don't scaffold; they may have run this by mistake.
+  Confirm they mean to work here (else ask for an empty target dir for a new project),
+  then go to Step 4.
+- **Existing non-Rayfin app here:** confirm, then add Rayfin in place with
+  `npx -y rayfin init` (no template). Then Step 4.
+- **Empty directory:** scaffold a new child project. Map the Step 1 answer to a
+  template, then list the live set and pick the closest fit:
+
+  ```bash
+  npx -y @microsoft/create-rayfin@latest --list-templates   # JSON of gallery templates
+  ```
+
+  If unavailable, fall back to these built-in slugs (default `dataapp` for Fabric, or
+  `todoapp` if self-contained / no Fabric workspace):
+
+  - **`dataapp`** _(default)_: Microsoft Fabric data analytics app.
+  - **`todoapp`**: full app (auth, entities, frontend); best to learn Rayfin end-to-end.
+  - **`gettingstartedauth`**: minimal app with auth wired up; add your own data model.
+  - **`blankapp`**: bare scaffolding (auth + data services, no entities/UI).
+
+  For more options, including user-contributed ones, see the community gallery linked
+  at the end.
+
+  Prefer a template matching their domain over a blank one. Propose a kebab-case
+  project name, confirm it, then:
+
+  ```bash
+  npx -y @microsoft/create-rayfin@latest --project-name <name> --template <slug>
+  ```
+
+The scaffolder (or `init`) creates the project, installs dependencies, and writes
+agent rules + an MCP config, so don't redo that work. `cd` into the new `<name>/`
+child dir (`rayfin init` works in place, so you're already there). If `npx` errors,
+Node may be missing; see Step 2.
+
+## Step 4 — Load the in-project skill, then plan & customize
+
+Before writing any Rayfin-specific code, hand off to the project's authoritative,
+version-locked sources:
+
+1. Load `.agents/skills/rayfin/SKILL.md` and follow it; if your tooling supports it,
+   reload tools to bring the `rayfin` MCP online.
+2. Look up version-matched APIs via `rayfin docs` and the `rayfin` MCP instead of
+   guessing. The skill file and `rayfin docs` work as soon as the project exists, so
+   don't block waiting on the MCP reload.
+
+Then enter plan mode and outline the first changes for what they described in Step 1:
+entities under `rayfin/data/`, views under `src/`, and packages to install. Confirm
+with the user before writing code.
+
+Don't start the backend or frontend; the user runs the app themselves when ready (see
+the project's `README.md`).
+
+## Useful links
+
+- Docs: <http://aka.ms/rayfin/docs>
+- Scaffolder: <https://www.npmjs.com/package/@microsoft/create-rayfin>
+- Community template gallery: <https://github.com/microsoft/awesome-rayfin>

--- a/content/start.md
+++ b/content/start.md
@@ -1,4 +1,4 @@
-# Rayfin — New Project Setup
+# Rayfin: New Project Setup
 
 You're helping a developer create a new Rayfin project. Rayfin is a TypeScript
 Backend-as-a-Service: decorate data models to get auto-generated APIs (REST +
@@ -13,7 +13,7 @@ internals.
 **One question at a time:** whenever you need input from the user, ask a single
 question and wait for the answer before asking the next.
 
-## Step 1 — Detect context and ask what they want to build
+## Step 1: Detect context and ask what they want to build
 
 First, check the current directory: context signals are enough, even if you can't
 open the files. It's already a Rayfin project if it has `rayfin/rayfin.yml` or a
@@ -24,7 +24,7 @@ Then ask what they want to build. Infer whether it targets Microsoft Fabric or s
 be self-contained, only clarifying if it's unclear. This guides the template and
 later customization.
 
-## Step 2 — Check prerequisites
+## Step 2: Check prerequisites
 
 Before running any `npx` command: `node --version` (need 20+) and `git --version`.
 Install anything missing first:
@@ -35,7 +35,7 @@ Install anything missing first:
 
 Don't proceed until `node --version` reports v20+.
 
-## Step 3 — Get into a project
+## Step 3: Get into a project
 
 Act on the context from Step 1. You're not a TTY, so always pass `-y` to `npx` (bare
 `npm create` can mishandle piped stdin and strip flags).
@@ -75,7 +75,7 @@ agent rules + an MCP config, so don't redo that work. `cd` into the new `<name>/
 child dir (`rayfin init` works in place, so you're already there). If `npx` errors,
 Node may be missing; see Step 2.
 
-## Step 4 — Load the in-project skill, then plan & customize
+## Step 4: Load the in-project skill, then plan & customize
 
 Before writing any Rayfin-specific code, hand off to the project's authoritative,
 version-locked sources:

--- a/content/start.md
+++ b/content/start.md
@@ -26,11 +26,11 @@ Don't proceed until `node --version` reports v20+.
 
 Don't scaffold from memory: fetch the getting-started skill and follow it. It is the canonical source for project detection, the default template, and the exact CLI commands, and it is kept up to date as those change.
 
-```bash
-curl -sSfL https://raw.githubusercontent.com/microsoft/rayfin/main/skills/rayfin-getting-started/SKILL.md
-```
+Fetch and read this URL with your web fetch capability, rather than a shell command, so this works the same on any platform:
 
-Read it, then follow it to detect whether you're already in a Rayfin project, in an existing non-Rayfin app, or in an empty directory, and to run the right command for that case. Feed it what you learned in Step 1: what the user wants to build, and a kebab-case project name you've confirmed with them.
+<https://raw.githubusercontent.com/microsoft/rayfin/main/skills/rayfin-getting-started/SKILL.md>
+
+Then follow it to detect whether you're already in a Rayfin project, in an existing non-Rayfin app, or in an empty directory, and to run the right command for that case. Feed it what you learned in Step 1: what the user wants to build, and a kebab-case project name you've confirmed with them.
 
 Two things that skill assumes and this prompt has already covered: Node is installed (Step 2), and you're not a TTY, so keep passing `-y` to `npx`. If `npx` errors, Node may be missing; see Step 2.
 

--- a/content/start.md
+++ b/content/start.md
@@ -14,13 +14,13 @@ Keep it short if the working directory already looks like an existing app: Step 
 
 ## Step 2: Check prerequisites
 
-Before running any `npx` command: `node --version` (need 20+) and `git --version`. Install anything missing first:
+Before running any `npx` command: `node --version` and `git --version`. Rayfin supports even-numbered Node majors only, so you need **v20.x, v22.x, or v24.x**: an odd or newer major like 21, 23, or 25 passes a naive "20 or later" check and then fails at install time. Install anything missing first:
 
 - macOS: `brew install node git`
-- Windows: `winget install -e --id OpenJS.NodeJS.LTS Git.Git`
+- Windows: `winget install -e --id OpenJS.NodeJS.LTS` then `winget install -e --id Git.Git`
 - Linux (Debian/Ubuntu): Node from [nodejs.org/en/download](https://nodejs.org/en/download), then `sudo apt install -y git`
 
-Don't proceed until `node --version` reports v20+.
+Don't proceed until `node --version` reports v20.x, v22.x, or v24.x.
 
 ## Step 3: Get into a project
 

--- a/content/start.md
+++ b/content/start.md
@@ -14,13 +14,13 @@ Keep it short if the working directory already looks like an existing app: Step 
 
 ## Step 2: Check prerequisites
 
-Before running any `npx` command: `node --version` and `git --version`. Rayfin supports even-numbered Node majors only, so you need **v20.x, v22.x, or v24.x**: an odd or newer major like 21, 23, or 25 passes a naive 20-or-later check and then fails at install time. Install anything missing first:
+Before running any `npx` command: `node --version` and `git --version`. Rayfin supports Node **LTS** releases, currently v20, v22 and v24. Odd-numbered major like 21, 23 or 25 are unsupported. Install anything missing first:
 
-- macOS: `brew install node@24 git`, then `brew link --overwrite --force node@24` to put it on your PATH. The unversioned `node` formula tracks Node Current, which is usually out of range.
+- macOS: install the LTS build from [nodejs.org/en/download](https://nodejs.org/en/download), which defaults to LTS. Homebrew's `node` formula tracks Current, so avoid it here. For git, use `brew install git` or the Xcode Command Line Tools.
 - Windows: `winget install -e --id OpenJS.NodeJS.LTS` then `winget install -e --id Git.Git`
-- Linux (Debian/Ubuntu): install Node 24 via [NodeSource](https://github.com/nodesource/distributions), then `sudo apt install -y git`
+- Linux (Debian/Ubuntu): `curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -` then `sudo apt install -y nodejs git`
 
-Don't proceed until `node --version` reports v20.x, v22.x, or v24.x.
+Don't proceed until `node --version` reports an LTS release, meaning v20.x, v22.x or v24.x today. When a newer LTS line ships, prefer it, and fall back to the most recent LTS the scaffolder accepts if it rejects the brand-new one.
 
 ## Step 3: Get into a project
 

--- a/content/start.md
+++ b/content/start.md
@@ -14,11 +14,11 @@ Keep it short if the working directory already looks like an existing app: Step 
 
 ## Step 2: Check prerequisites
 
-Before running any `npx` command: `node --version` and `git --version`. Rayfin supports even-numbered Node majors only, so you need **v20.x, v22.x, or v24.x**: an odd or newer major like 21, 23, or 25 passes a naive "20 or later" check and then fails at install time. Install anything missing first:
+Before running any `npx` command: `node --version` and `git --version`. Rayfin supports even-numbered Node majors only, so you need **v20.x, v22.x, or v24.x**: an odd or newer major like 21, 23, or 25 passes a naive 20-or-later check and then fails at install time. Install anything missing first:
 
-- macOS: `brew install node git`
+- macOS: `brew install node@24 git`, then `brew link --overwrite --force node@24` to put it on your PATH. The unversioned `node` formula tracks Node Current, which is usually out of range.
 - Windows: `winget install -e --id OpenJS.NodeJS.LTS` then `winget install -e --id Git.Git`
-- Linux (Debian/Ubuntu): Node from [nodejs.org/en/download](https://nodejs.org/en/download), then `sudo apt install -y git`
+- Linux (Debian/Ubuntu): install Node 24 via [NodeSource](https://github.com/nodesource/distributions), then `sudo apt install -y git`
 
 Don't proceed until `node --version` reports v20.x, v22.x, or v24.x.
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project."
 }

--- a/kimi-marketplace.json
+++ b/kimi-marketplace.json
@@ -4,7 +4,7 @@
     {
       "id": "rayfin",
       "displayName": "Rayfin",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "description": "Get started building a Rayfin app with the Rayfin CLI.",
       "homepage": "https://github.com/microsoft/rayfin",
       "keywords": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "rayfin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -47,8 +47,8 @@ project and continue in place. Never stand up a nested or sibling project.
 - **Already in one →** load `.agents/skills/rayfin/SKILL.md` and use the `rayfin` MCP /
   `rayfin docs`. Stop using this skill.
 - **Existing non-Rayfin app here →** add Rayfin in place with
-  `npx -y -p @microsoft/rayfin-cli@latest rayfin init` (don't scaffold a separate
-  project), then load the in-project skill.
+  `npx -y -p @microsoft/rayfin-cli@latest rayfin init --project-name <app-name>` (don't
+  scaffold a separate project), then load the in-project skill.
 - **Empty directory →** scaffold (below), then load the in-project skill from the project root.
 
 ## Scaffold a new project
@@ -65,8 +65,8 @@ mishandle piped stdin and strip flags, and `--project-name` is **required** non-
 # it fails to parse instead of continuing.
 npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template https://github.com/microsoft/awesome-rayfin --template-name "Universal App"
 
-# Or add Rayfin into an existing/empty directory. 
-npx -y -p @microsoft/rayfin-cli@latest rayfin init [directory]
+# Or add Rayfin into an existing directory.
+npx -y -p @microsoft/rayfin-cli@latest rayfin init --project-name <app-name> [directory]
 
 # Templates bundled with the CLI (JSON), only if you need a different starting point
 npx -y @microsoft/create-rayfin@latest --list-templates

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -3,7 +3,7 @@ name: rayfin-getting-started
 description: "Use when starting or creating a NEW Rayfin app, or when a Rayfin task comes up and you are not yet inside a Rayfin project. Gets you into a project with the Rayfin CLI, then hands off to the authoritative, version-locked in-project rayfin skill/MCP/docs that own all in-project work. Triggers: build a Rayfin app, start a Rayfin project, create a new Rayfin app, create-rayfin, npm create @microsoft/rayfin, rayfin init, scaffold rayfin, rayfin CLI, rayfin template, universal app, awesome-rayfin gallery, get started with Rayfin"
 metadata:
   author: microsoft
-  version: "0.2.0"
+  version: "0.2.1"
 ---
 
 # Rayfin (Getting Started)
@@ -46,8 +46,9 @@ project and continue in place. Never stand up a nested or sibling project.
 
 - **Already in one →** load `.agents/skills/rayfin/SKILL.md` and use the `rayfin` MCP /
   `rayfin docs`. Stop using this skill.
-- **Existing non-Rayfin app here →** add Rayfin in place with `npx rayfin init` (don't
-  scaffold a separate project), then load the in-project skill.
+- **Existing non-Rayfin app here →** add Rayfin in place with
+  `npx -y -p @microsoft/rayfin-cli@latest rayfin init` (don't scaffold a separate
+  project), then load the in-project skill.
 - **Empty directory →** scaffold (below), then load the in-project skill from the project root.
 
 ## Scaffold a new project
@@ -64,8 +65,12 @@ mishandle piped stdin and strip flags, and `--project-name` is **required** non-
 # it fails to parse instead of continuing.
 npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template https://github.com/microsoft/awesome-rayfin --template-name "Universal App"
 
-# Or add Rayfin into an existing/empty directory
-npx rayfin init [directory]
+# Or add Rayfin into an existing/empty directory. The CLI ships as
+# @microsoft/rayfin-cli, whose bin is `rayfin`, so npx needs the explicit
+# -p <package> <bin> form: `npx @microsoft/rayfin-cli` looks for a `rayfin-cli`
+# command, finds none, and exits 1 without printing anything. There is no
+# public `rayfin` package either, so plain `npx rayfin` 404s.
+npx -y -p @microsoft/rayfin-cli@latest rayfin init [directory]
 
 # Templates bundled with the CLI (JSON), only if you need a different starting point
 npx -y @microsoft/create-rayfin@latest --list-templates

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -65,11 +65,7 @@ mishandle piped stdin and strip flags, and `--project-name` is **required** non-
 # it fails to parse instead of continuing.
 npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template https://github.com/microsoft/awesome-rayfin --template-name "Universal App"
 
-# Or add Rayfin into an existing/empty directory. The CLI ships as
-# @microsoft/rayfin-cli, whose bin is `rayfin`, so npx needs the explicit
-# -p <package> <bin> form: `npx @microsoft/rayfin-cli` looks for a `rayfin-cli`
-# command, finds none, and exits 1 without printing anything. There is no
-# public `rayfin` package either, so plain `npx rayfin` 404s.
+# Or add Rayfin into an existing/empty directory. 
 npx -y -p @microsoft/rayfin-cli@latest rayfin init [directory]
 
 # Templates bundled with the CLI (JSON), only if you need a different starting point


### PR DESCRIPTION
## Description

`content/start.md` is a self-contained, end-to-end setup prompt a coding agent (e.g. GitHub Copilot CLI) can run to go from zero to a customized Rayfin app: it checks prerequisites, installs what's missing, scaffolds the most appropriate template, then customizes with the user through guided questions. Linked from the README "Getting Started" section as an optional path.

Complementary to the existing `rayfin-getting-started` skill: same routing/handoff philosophy, packaged as one runnable prompt that covers the full flow.

> Note: the `aka.ms/rayfin/start.md` short link will be repointed to the raw GitHub file after this PR merges.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Other

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My changes follow the existing code style
- [ ] I have tested my changes locally
- [x] I have updated documentation as needed

## AI disclosure

Drafted with GitHub Copilot CLI and reviewed by the author; the prompt was validated against its goals with two independent rubber-duck reviews (GPT-5.5 and Claude).
