### PR TITLE
docs(plugin): default the getting-started skill to the Universal App from awesome-rayfin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Rayfin agent skills for AI coding assistants",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "rayfin",
       "description": "Getting-started router for Rayfin - gets an agent from zero into a working Rayfin project via the Rayfin CLI (scaffold/init), then hands off to the version-locked in-project skill the scaffold installs.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Official Rayfin agent skills for AI coding assistants",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "rayfin",
       "description": "Getting-started router for Rayfin — gets an agent from zero into a working Rayfin project via the Rayfin CLI (scaffold/init), then hands off to the version-locked in-project skill the scaffold installs.",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "source": "./"
     }
   ]

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project."
 }

--- a/kimi-marketplace.json
+++ b/kimi-marketplace.json
@@ -4,7 +4,7 @@
     {
       "id": "rayfin",
       "displayName": "Rayfin",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "description": "Get started building a Rayfin app with the Rayfin CLI.",
       "homepage": "https://github.com/microsoft/rayfin",
       "keywords": [

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "rayfin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Getting-started router skill for Rayfin - scaffold a new app with the Rayfin CLI, then use the version-locked skill installed in the project.",
   "author": {
     "name": "Microsoft",

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -57,17 +57,20 @@ run non-interactively (stdin isn't a TTY), so use the `npx -y` form — `npm cre
 mishandle piped stdin and strip flags, and `--project-name` is **required** non-interactively.
 
 ```bash
-# Default: the Universal App template. --template takes a template name or a git URL.
+# Default: the Universal App, from the awesome-rayfin gallery. --template takes a
+# template name or a git URL; --template-name selects one entry out of a repo that
+# holds several, matched on the entry's display name.
 npx -y @microsoft/create-rayfin@latest --project-name <app-name> \
-  --template https://github.com/spatney/universal-app
+  --template https://github.com/microsoft/awesome-rayfin \
+  --template-name "Universal App"
 
 # Or add Rayfin into an existing/empty directory
 npx rayfin init [directory]
 
-# Built-in gallery templates (JSON), only if you need a different starting point
+# Templates bundled with the CLI (JSON), only if you need a different starting point
 npx -y @microsoft/create-rayfin@latest --list-templates
 
-# Gallery templates take a slug (e.g. dataapp, gettingstartedauth), not a display name
+# Bundled templates take a slug (e.g. dataapp, gettingstartedauth), not a display name
 npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template <slug>
 ```
 
@@ -76,8 +79,12 @@ Fabric-authenticated React + Vite starter that grows into whatever the user desc
 capability router (`AGENTS.md` plus `.agents/skills/capability-router/`) maps the request to
 capability packs and pulls in only the Rayfin services, npm modules, and skills that app
 actually needs, covering auth, data modeling, storage, charts, and Fabric analytics. That means
-you don't have to guess a domain template up front, so prefer it over picking a gallery
+you don't have to guess a domain template up front, so prefer it over picking a domain
 template that merely looks close.
+
+`--template-name` is not optional against `awesome-rayfin`. The repo holds a whole gallery, so
+omitting it aborts the scaffold and prints every entry, which is also the quickest way to see
+what else is on offer.
 
 Mind the project root before loading the in-project skill: `create-rayfin` creates a child
 project directory (named from `--project-name`, slugified), so `cd` into it; an in-place

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -3,7 +3,7 @@ name: rayfin-getting-started
 description: "Use when starting or creating a NEW Rayfin app, or when a Rayfin task comes up and you are not yet inside a Rayfin project. Gets you into a project with the Rayfin CLI, then hands off to the authoritative, version-locked in-project rayfin skill/MCP/docs that own all in-project work. Triggers: build a Rayfin app, start a Rayfin project, create a new Rayfin app, create-rayfin, npm create @microsoft/rayfin, rayfin init, scaffold rayfin, rayfin CLI, rayfin template, universal app, awesome-rayfin gallery, get started with Rayfin"
 metadata:
   author: microsoft
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Rayfin (Getting Started)

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rayfin-getting-started
-description: "Use when starting or creating a NEW Rayfin app, or when a Rayfin task comes up and you are not yet inside a Rayfin project. Gets you into a project with the Rayfin CLI, then hands off to the authoritative, version-locked in-project rayfin skill/MCP/docs that own all in-project work. Triggers: build a Rayfin app, start a Rayfin project, create a new Rayfin app, create-rayfin, npm create @microsoft/rayfin, rayfin init, scaffold rayfin, rayfin CLI, rayfin template, awesome-rayfin gallery, get started with Rayfin"
+description: "Use when starting or creating a NEW Rayfin app, or when a Rayfin task comes up and you are not yet inside a Rayfin project. Gets you into a project with the Rayfin CLI, then hands off to the authoritative, version-locked in-project rayfin skill/MCP/docs that own all in-project work. Triggers: build a Rayfin app, start a Rayfin project, create a new Rayfin app, create-rayfin, npm create @microsoft/rayfin, rayfin init, scaffold rayfin, rayfin CLI, rayfin template, universal app, awesome-rayfin gallery, get started with Rayfin"
 metadata:
   author: microsoft
   version: "0.1.0"
@@ -57,20 +57,30 @@ run non-interactively (stdin isn't a TTY), so use the `npx -y` form — `npm cre
 mishandle piped stdin and strip flags, and `--project-name` is **required** non-interactively.
 
 ```bash
-# List built-in gallery templates (JSON), then create from the closest fit
-npx -y @microsoft/create-rayfin@latest --list-templates
-
-# Create non-interactively — --project-name required; --template takes a slug
-# (e.g. dataapp, gettingstartedauth), not a display name
-npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template <slug>
+# Default: the Universal App template. --template takes a template name or a git URL.
+npx -y @microsoft/create-rayfin@latest --project-name <app-name> \
+  --template https://github.com/spatney/universal-app
 
 # Or add Rayfin into an existing/empty directory
 npx rayfin init [directory]
+
+# Built-in gallery templates (JSON), only if you need a different starting point
+npx -y @microsoft/create-rayfin@latest --list-templates
+
+# Gallery templates take a slug (e.g. dataapp, gettingstartedauth), not a display name
+npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template <slug>
 ```
 
-Prefer a gallery template matching the user's domain (events, field service, todo, CRUD) over
-an empty project — it ships a working data model, auth, and UI. Mind the project root before
-loading the in-project skill: `create-rayfin` creates a child project directory (named from
-`--project-name`, slugified), so `cd` into it; an in-place `rayfin init` scaffolds in the
-current directory, so you're already there. Once at the project root, load its
-`.agents/skills/rayfin/SKILL.md`.
+Default to the **Universal App** unless the user asks for something else. It is a lean
+Fabric-authenticated React + Vite starter that grows into whatever the user describes: a
+capability router (`AGENTS.md` plus `.agents/skills/capability-router/`) maps the request to
+capability packs and pulls in only the Rayfin services, npm modules, and skills that app
+actually needs, covering auth, data modeling, storage, charts, and Fabric analytics. That means
+you don't have to guess a domain template up front, so prefer it over picking a gallery
+template that merely looks close.
+
+Mind the project root before loading the in-project skill: `create-rayfin` creates a child
+project directory (named from `--project-name`, slugified), so `cd` into it; an in-place
+`rayfin init` scaffolds in the current directory, so you're already there. Once at the project
+root, read `AGENTS.md` first when the template ships a capability router, then load
+`.agents/skills/rayfin/SKILL.md` for every version-locked Rayfin specific.

--- a/skills/rayfin-getting-started/SKILL.md
+++ b/skills/rayfin-getting-started/SKILL.md
@@ -59,10 +59,10 @@ mishandle piped stdin and strip flags, and `--project-name` is **required** non-
 ```bash
 # Default: the Universal App, from the awesome-rayfin gallery. --template takes a
 # template name or a git URL; --template-name selects one entry out of a repo that
-# holds several, matched on the entry's display name.
-npx -y @microsoft/create-rayfin@latest --project-name <app-name> \
-  --template https://github.com/microsoft/awesome-rayfin \
-  --template-name "Universal App"
+# holds several, matched on the entry's display name. Keep this on one line: a
+# trailing \ is a bash continuation, and agents run this in PowerShell too, where
+# it fails to parse instead of continuing.
+npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template https://github.com/microsoft/awesome-rayfin --template-name "Universal App"
 
 # Or add Rayfin into an existing/empty directory
 npx rayfin init [directory]


### PR DESCRIPTION
## What

Makes the getting-started skill default to the **Universal App**, sourced from the [`microsoft/awesome-rayfin`](https://github.com/microsoft/awesome-rayfin) gallery, instead of leading with the CLI's bundled slugs.

Skill content and version metadata only. No code.

## Why the command grew a flag

`awesome-rayfin` is a multi-template repo: its root `rayfin-template.yml` lists ten entries, of which `templates/universal-app` is one. A multi-template source requires `--template-name` to pick an entry, so the documented command carries it:

```bash
npx -y @microsoft/create-rayfin@latest --project-name <app-name> --template https://github.com/microsoft/awesome-rayfin --template-name "Universal App"
```

Omitting the flag is not a soft failure. The CLI aborts and cleans up the partial project, which would have made a bare `--template <url>` form actively broken for agents running non-interactively. The value matches the entry's display name (`Universal App`); a path like `templates/universal-app` also resolves but warns.

The command stays on one line deliberately. A trailing `\` is a bash line continuation, and PowerShell does not honor it: the line fails to parse outright with `Missing expression after unary operator '--'`, so the command dies before `npx` ever runs. Agents run this skill on Windows, so the wrapped form was a real break rather than a cosmetic one.

## Why the Universal App as the default

It is a lean Fabric-authenticated React and Vite starter with a capability router (`AGENTS.md` plus `.agents/skills/capability-router/`) that maps the user's request to capability packs, then enables only the Rayfin services, modules, and skills that app needs. That removes the need to guess a domain template up front, which is a better default than picking a gallery entry that merely looks close.

## Versioning

This changes shipped behavior, so it carries a release:

- Getting-started skill `0.1.0` to `0.2.0` (`skills/rayfin-getting-started/SKILL.md`).
- Plugin `0.3.0` to `0.4.0` across all nine harness manifests and the three marketplace descriptors, twelve fields in total.

The top-level `version` in `kimi-marketplace.json` stays at `1`. That field is the marketplace schema version, not the plugin version.

The template URL stays unpinned and tracks the gallery's default branch, so the skill picks up gallery updates without a change here.

## Verification

Scaffolded end to end against the real gallery:

- **Negative:** bare `--template https://github.com/microsoft/awesome-rayfin` fails with `Multiple templates found. Use --template-name to specify one.` and lists all ten entries.
- **Positive:** with `--template-name "Universal App"`, the project scaffolds, dependencies install, and the sync step still lands `.agents/skills/rayfin/SKILL.md`, `.mcp.json`, and `AGENTS.md`.

That last point matters most: this skill's whole job is to hand off to the in-project skill, and the handoff contract is intact.

Every manifest was re-parsed as JSON after the version bump, and the diff is thirteen changed lines, all of them `version` fields.

## Note

An earlier revision of this PR pointed at a personal repo that held the template before it moved into the Microsoft gallery. Sourcing from `awesome-rayfin` also settles the licensing question that raised, since that repo ships its own LICENSE.
